### PR TITLE
Make it possible to turn off safe rendering over the Metadata of a File

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -5,5 +5,8 @@ exports.bundle = "./dist/views.js";
 exports.viewName = "render";
 exports.targetDir = "./dist/site";
 exports.transforms = {
-	md: (txt, { safe, smart }) => require("./markdown")(txt, { safe: safe !== "false", smart })
+	md: (txt, { safe, smart }) => require("./markdown")(txt, {
+		safe: safe !== "false",
+		smart: smart !== "false"
+	})
 };

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -5,5 +5,5 @@ exports.bundle = "./dist/views.js";
 exports.viewName = "render";
 exports.targetDir = "./dist/site";
 exports.transforms = {
-	md: (txt, { safe, smart }) => require("./markdown")(txt, { safe, smart })
+	md: (txt, { safe, smart }) => require("./markdown")(txt, { safe: safe !== "false", smart })
 };


### PR DESCRIPTION
I looked into here why the `safe` setting isn't available in the markdown file and it is because all of the Metadata that comes from the file is passed is a string.

This means that the metadata `safe: false` appears in a document, this will be translated into the JavaScript Object `{ safe: "false" }`

This is currently a quick fix to allow this option to be correctly passed into the `renderMarkdown` function. However, I'm not completely happy with it, especially because I feel like the syntax in `transforms` should be as succinct as possible, but also because to be consistent we would have to also set `smart: smart !== false`.

## Alternatives
Some alternatives that I have considered and could implement:

Option 1 (shown here):
Modify the the metadata in the transform function and pass it into 
Con: the `transform` function is less succinct

Option 2
Perform the modification here: https://github.com/complate/complate-ssg/blob/master/src/page.js#L40
Pro: This is directly when we extract the metadata from a file
Con: At this point, the transform function doesn't actually know which metadata fields are interesting and which metadata attributes should be interpreted as booleans.

Option 3
Modify the `renderMarkdown` function here https://github.com/complate/complate-ssg/blob/master/src/markdown.js#L6 so that it also knows what to do with string parameters.

## Which option should we use?

I think that if we want to have the same handling of the metadata for all file types (e.g. `safe` and `smart` should be interpreted as boolean values, even when we are dealing with asciidoc files instead of Markdown), then we should go with Option 2. Otherwise, I think Option 3 might be the best.

